### PR TITLE
Fixed a bug in listing.html.twig

### DIFF
--- a/templates/partials/page/listing.html.twig
+++ b/templates/partials/page/listing.html.twig
@@ -23,7 +23,7 @@
         {% endif %}
         </section>
         <footer>
-            {% include 'partials/taxonomy.html.twig' with {page: item} %}
+            {% include 'partials/taxonomy.html.twig' with {item: page} %}
         </footer>
     </article>
     {% endfor %}


### PR DESCRIPTION
In listings, the date is set to the current date for all listed elements, not the date of the listed page. This bug is also present at https://olevik.me/staging/grav-skeleton-scholar/